### PR TITLE
Windows ortam hatası düzeltme

### DIFF
--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -8,21 +8,17 @@ import rootReducer from './modules';
 const configureStore = (prelodedState, history) => {
   const middlewares = [thunk, routerMiddleware(history)];
 
+  const composed = [applyMiddleware(...middlewares)];
+
+  const store = createStore(rootReducer, prelodedState, compose(...composed));
+  
   /* istanbul ignore if */
   if (process.env.NODE_ENV === 'development') {
     middlewares.push(createLogger());
-  }
-
-  const composed = [applyMiddleware(...middlewares)];
-
-  /* istanbul ignore if */
-  if (process.env.NODE_ENV === 'development') {
     /* eslint-disable */
     composed.push(window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__());
     /* eslint-enable */
   }
-
-  const store = createStore(rootReducer, prelodedState, compose(...composed));
 
   /* istanbul ignore if */
   if (process.env.NODE_ENV === 'development' && module.hot) {


### PR DESCRIPTION
Windows cihazda Redux dev tool kurulu olmayan chromede aşşağıdaki composed e push ettiğimiz noktayı görmüyordu
Şöyle Bir Hata dönüyordu
Uncaught TypeError: Cannot read property 'apply' of undefined
    at compose.js:36
    at createStore (createStore.js:65)
    at configureStore (configureStore.js:25)
    at Object.<anonymous> (index.js:16)
    at __webpack_require__ (bootstrap edb387f…:555)
    at fn (bootstrap edb387f…:86)
    at Object.<anonymous> (bootstrap edb387f…:578)
    at __webpack_require__ (bootstrap edb387f…:555)
    at bootstrap edb387f…:578
    at bootstrap edb387f…:578

Bu şekilde Push yaptığımız bölümü tanımlamaların altına alınca hata düzeldi mac de test edemedim